### PR TITLE
remove non-root url from deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,8 +23,6 @@ jobs:
       # Pick your own package manager and build script
       - run: yarn install
       - run: npx nuxt build --preset github_pages
-        env:
-          NUXT_APP_BASE_URL: /balance-xiv/
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:


### PR DESCRIPTION
We're having too much trouble of getting some of the asset paths working right when using a non-root domain. 

We don't anticipate running this at a non-root domain, so for now for practicality we're reconfiguring the deployment for this repo to run at `xiv.sneakycrow.dev`